### PR TITLE
Set configurations from environment variables

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -49,6 +49,8 @@ Environment Variables
 
   * `MUTE_CONFIG`: full/relative path to the config file. default is `/etc/mute.toml`, no file no issue.
     an empty value means no config file lookup.
+  * `MUTE_EXIT_CODES`: comma separated list of exit codes to suppress (same as `exit_codes` in `mute.default` config)
+  * `MUTE_STDOUT_PATTERN`: regex pattern to suppress the output when stdout matches
 
 
 Configuration File

--- a/README.rst
+++ b/README.rst
@@ -18,6 +18,9 @@ Usage
     mute bash -c "echo 'this is muted'"
     mute bash -c "echo 'this is printed, exiting with 12'; exit 12"
 
+    # configure mute with environment variables
+    env MUTE_EXIT_CODES="4,5" mute bash -c "echo 'muted'; exit 4"
+    env MUTE_STDOUT_PATTERN=".*OK.*" mute bash -c "echo 'warning but OK so muted'; exit 1"
 
 `mute` accepts a command with optional arguments to run. `mute` itself
 has no arguments and can be configured with a file (in `TOML <https://github.com/toml-lang/toml>`_),
@@ -33,9 +36,16 @@ and with 126 (`mute.ExitErrConf`) when configuration is invalid.
 Configuration
 -------------
 
+`mute` can be configured with environment variables, or with a configuration file.
+If the environment variables are set, they define the current configuration and
+the config file is not even checked. If no variables are defined or they are all empty,
+then the configuration file is checked.
+
 If the configuration file does not exist, or is not accessile (permissions, etc.)
 mute continues with the default configuration.
-Any accessible configuration should be valid otherwise mute exits with `mute.ExitErrConf`.
+
+Any accessible configuration should be valid otherwise mute exits with `mute.ExitErrConf` (
+also applies to environment variables).
 
 
 Default Config
@@ -47,10 +57,10 @@ exit code 0 and any output pattern.
 Environment Variables
 =====================
 
-  * `MUTE_CONFIG`: full/relative path to the config file. default is `/etc/mute.toml`, no file no issue.
-    an empty value means no config file lookup.
   * `MUTE_EXIT_CODES`: comma separated list of exit codes to suppress (same as `exit_codes` in `mute.default` config)
   * `MUTE_STDOUT_PATTERN`: regex pattern to suppress the output when stdout matches
+  * `MUTE_CONFIG`: full/relative path to the config file. default is `/etc/mute.toml`, no file no issue.
+    an empty value means no config file lookup.
 
 
 Configuration File

--- a/README.rst
+++ b/README.rst
@@ -23,20 +23,38 @@ Usage
 has no arguments and can be configured with a file (in `TOML <https://github.com/toml-lang/toml>`_),
 and environment variables.
 
-The exit code of `mute` is the exit code of the command to execute.
-`mute` exits with 127 (`mute.exec.EXEC_ERR`) when failed to execute the commnad.
+Configuration is validated before running the program.
 
-
-Environment Variables
----------------------
-
-Environment variables override config file directives.
-
-  * `MUTE_CONFIG`: full/relative path to the config file. default is `/etc/mute.toml`, no file no issue.
+The exit code of `mute` is the exit code of the command it runs.
+However `mute` exits with 127 (`mute.ExitErrExec`) when failed to execute the commnad,
+and with 126 (`mute.ExitErrConf`) when configuration is invalid.
 
 
 Configuration
 -------------
+
+If the configuration file does not exist, or is not accessile (permissions, etc.)
+mute continues with the default configuration.
+Any accessible configuration should be valid otherwise mute exits with `mute.ExitErrConf`.
+
+
+Default Config
+==============
+When there is no config specified, mute suppresses output from successful runs, matching
+exit code 0 and any output pattern.
+
+
+Environment Variables
+=====================
+
+  * `MUTE_CONFIG`: full/relative path to the config file. default is `/etc/mute.toml`, no file no issue.
+    an empty value means no config file lookup.
+
+
+Configuration File
+===================
+
+The accessible configuration file should contain valid criteria defenitions in TOML format.
 
 
 .. code-block::
@@ -68,7 +86,6 @@ Configuration
       # Command specific settings can also be grouped with OR by repeating the settings
       [[ commands.user ]]
       stdout_patterns = ["^$"]  # now any command starting with "user" will match when output is empty regardless of exit code
-
 
 
 License

--- a/cmd/mute.go
+++ b/cmd/mute.go
@@ -10,19 +10,19 @@ import (
 func main() {
 	if len(os.Args) < 2 {
 		fmt.Fprintf(os.Stderr, "version %v. Usage: %v COMMAND", mute.Version, os.Args[0])
-		os.Exit(mute.EXEC_ERR)
+		os.Exit(mute.ExitErrExec)
 	}
-	// use config file if readable, otherwise use a default conf
+	// use config file if accessible, otherwise use a default conf
 	// to mute zero exit codes
-	confPath := "/etc/mute.toml"
-	envConf, envSet := os.LookupEnv("MUTE_CONFIG")
-	if envSet {
-		confPath = envConf
-	}
-	conf, err := mute.ReadConfFile(confPath)
+	conf, err := mute.GetCmdConf()
 	if err != nil {
-		conf = *mute.DefaultConf()
+		if _, ok := err.(mute.ConfAccessError); ok {
+			conf = mute.DefaultConf()
+		} else {
+			fmt.Fprintf(os.Stderr, "config error:  %v", err)
+			os.Exit(mute.ExitErrConf)
+		}
 	}
-	exitCode := mute.Exec(os.Args[1], os.Args[2:], &conf, os.Stdout)
+	exitCode := mute.Exec(os.Args[1], os.Args[2:], conf, os.Stdout)
 	os.Exit(exitCode)
 }

--- a/conf.go
+++ b/conf.go
@@ -175,7 +175,13 @@ func (c *Criteria) equal(c2 *Criteria) bool {
 
 // Conf.equal check if Conf items are the same
 func (c *Conf) equal(c2 *Conf) bool {
+	// @TODO: implement checking equality of commands criteria
 	return c.Default.equal(&(c2.Default))
+}
+
+// Conf.IsEmpty determines if the Conf is empty
+func (c *Conf) IsEmpty() bool {
+	return len(c.Default) < 1 && len(c.Commands) < 1
 }
 
 func (e ConfAccessError) Error() string {

--- a/conf.go
+++ b/conf.go
@@ -13,6 +13,9 @@ import (
 
 // Version is the program version
 const Version string = "0.1.0"
+const ENV_CONFIG string = "MUTE_CONFIG"
+const ENV_EXIT_CODES string = "MUTE_EXIT_CODES"
+const ENV_STDOUT_PATTERN string = "MUTE_STDOUT_PATTERN"
 
 // ExitErrConf is exit code when config is invalid
 const ExitErrConf = 126
@@ -257,9 +260,17 @@ func ConfFromEnvStr(exitCodesStr, pattern string) (*Conf, error) {
 func GetCmdConf() (*Conf, error) {
 	var conf *Conf
 	var err error
-	confPath := "/etc/mute.toml"
 
-	envConfPath, envConfSet := os.LookupEnv("MUTE_CONFIG")
+	envExitCodes := os.Getenv(ENV_EXIT_CODES)
+	envPattern := os.Getenv(ENV_STDOUT_PATTERN)
+	conf, err = ConfFromEnvStr(envExitCodes, envPattern)
+
+	if err != nil || !conf.IsEmpty() {
+		return conf, err
+	}
+
+	confPath := "/etc/mute.toml"
+	envConfPath, envConfSet := os.LookupEnv(ENV_CONFIG)
 	if envConfSet {
 		confPath = envConfPath
 		if confPath == "" {

--- a/conf.go
+++ b/conf.go
@@ -175,8 +175,24 @@ func (c *Criteria) equal(c2 *Criteria) bool {
 
 // Conf.equal check if Conf items are the same
 func (c *Conf) equal(c2 *Conf) bool {
-	// @TODO: implement checking equality of commands criteria
-	return c.Default.equal(&(c2.Default))
+	var c1Crt, c2Crt Criteria
+	var cmd string
+	var ok bool
+	if !c.Default.equal(&(c2.Default)) {
+		return false
+	}
+	if len(c.Commands) != len(c2.Commands) {
+		return false
+	}
+	for cmd, c1Crt = range c.Commands {
+		if c2Crt, ok = c2.Commands[cmd]; !ok {
+			return false
+		}
+		if !c1Crt.equal(&c2Crt) {
+			return false
+		}
+	}
+	return true
 }
 
 // Conf.IsEmpty determines if the Conf is empty

--- a/conf_test.go
+++ b/conf_test.go
@@ -119,6 +119,42 @@ func TestDefaultConf(t *testing.T) {
 	}
 }
 
+func TestConfEqual(t *testing.T) {
+	crt := NewCriterion([]int{1, 2}, []string{"OK"})
+
+	empty1 := new(Conf)
+	empty2 := new(Conf)
+	simple1 := createSimpleConf()
+	simple2 := createSimpleConf()
+
+	cmd1 := createSimpleConf()
+	cmd1.Commands["/usr/local/bin/mute"] = Criteria{crt}
+
+	cmd2 := createSimpleConf()
+	cmd2.Commands["/usr/local/bin/mute"] = Criteria{crt}
+
+	if !empty1.equal(empty2) {
+		t.Errorf("Conf empty1 should be equal to empty2")
+	}
+
+	if !simple1.equal(simple2) {
+		t.Errorf("Conf simple should be equal to simple2")
+	}
+
+	if empty1.equal(simple1) {
+		t.Errorf("Conf empty should not be equal to simple")
+	}
+
+	if !cmd1.equal(cmd2) {
+		t.Errorf("Conf cmd1 should be equal to cmd2")
+	}
+
+	cmd2.Commands["test"] = Criteria{crt}
+	if cmd1.equal(cmd2) {
+		t.Errorf("Conf cmd1 should not be equal to cmd2 with extra command")
+	}
+}
+
 func TestReadConfFileError(t *testing.T) {
 	_, err := ReadConfFile("fixtures/no_such_file.toml")
 	if err == nil {
@@ -223,5 +259,6 @@ func createSimpleConf() *Conf {
 	c2 := NewCriterion([]int{1, 2}, []string{"OK"})
 	conf := new(Conf)
 	conf.Default.add(c1).add(c2)
+	conf.Commands = make(map[string]Criteria)
 	return conf
 }

--- a/conf_test.go
+++ b/conf_test.go
@@ -44,7 +44,6 @@ func TestCriterionEmpty(t *testing.T) {
 	if !c3.IsEmpty() {
 		t.Errorf("Empty Criterion.IsEmpty 'false' want 'true'")
 	}
-
 }
 
 func TestCriterionEqual(t *testing.T) {
@@ -63,6 +62,27 @@ func TestCriterionEqual(t *testing.T) {
 	c2 = NewCriterion([]int{0, 1, 2}, []string{"ok"})
 	if c1.equal(c2) {
 		t.Errorf("Criterion.equal unmatched patterns got 'true' want 'false'")
+	}
+}
+
+func TestCriterionString(t *testing.T) {
+	var want, got string
+	var c1 *Criterion
+
+	c1 = NewCriterion([]int{0}, []string{})
+	want = "<Criterion codes=\"0\" patterns_count=\"0\">"
+	got = c1.String()
+
+	if want != got {
+		t.Errorf("Criterion String failed. want: '%v' got '%v'", want, got)
+	}
+
+	c1 = NewCriterion([]int{0}, []string{"OK"})
+	want = "<Criterion codes=\"0\" patterns_count=\"1\">"
+	got = c1.String()
+
+	if want != got {
+		t.Errorf("Criterion String failed. want: '%v' got '%v'", want, got)
 	}
 }
 
@@ -141,6 +161,40 @@ func TestReadConfFileSimple(t *testing.T) {
 	}
 }
 
+func TestConfFromEnvStr(t *testing.T) {
+	var got, want, defaultConf *Conf
+	var err error
+	defaultConf = DefaultConf()
+
+	want = new(Conf)
+	got, err = ConfFromEnvStr("", "")
+	if err != nil {
+		t.Errorf("ConfFromEnvStr empty want no error, got: %v", err)
+	}
+	if !want.equal(got) {
+		t.Errorf("ConfFromEnvStr want empty conf, got: %v", got)
+	}
+
+	got, err = ConfFromEnvStr("0", "")
+	if err != nil {
+		t.Errorf("ConfFromEnvStr default want no error, got: %v", err)
+	}
+	if !defaultConf.equal(got) {
+		t.Errorf("ConfFromEnvStr want default conf, got: %v", got)
+	}
+
+	want = new(Conf)
+	c1 := NewCriterion([]int{1, 2}, []string{"[0-9]test"})
+	want.Default.add(c1)
+	got, err = ConfFromEnvStr("1,2", "[0-9]test")
+	if err != nil {
+		t.Errorf("ConfFromEnvStr test want no error, got: %v", err)
+	}
+	if !want.equal(got) {
+		t.Errorf("ConfFromEnvStr test want: %v, got: %v", want, got)
+	}
+}
+
 func TestGetCmdConf(t *testing.T) {
 	os.Setenv("MUTE_CONFIG", "fixtures/simple.toml")
 	defer os.Unsetenv("MUTE_CONFIG")
@@ -164,6 +218,7 @@ func TestGetCmdConf(t *testing.T) {
 	}
 }
 
+// createSimpleConf returns a Conf with simple criterions for testing
 func createSimpleConf() *Conf {
 	c1 := NewCriterion([]int{0}, []string{})
 	c2 := NewCriterion([]int{1, 2}, []string{"OK"})

--- a/conf_test.go
+++ b/conf_test.go
@@ -166,12 +166,11 @@ func TestConfFromEnvStr(t *testing.T) {
 	var err error
 	defaultConf = DefaultConf()
 
-	want = new(Conf)
 	got, err = ConfFromEnvStr("", "")
 	if err != nil {
 		t.Errorf("ConfFromEnvStr empty want no error, got: %v", err)
 	}
-	if !want.equal(got) {
+	if !got.IsEmpty() {
 		t.Errorf("ConfFromEnvStr want empty conf, got: %v", got)
 	}
 

--- a/exec.go
+++ b/exec.go
@@ -9,8 +9,8 @@ import (
 	"strings"
 )
 
-// EXEC_ERR is exit code when failed to execute the command
-const EXEC_ERR = 127
+// ExitErrExec is exit code when failed to execute the command
+const ExitErrExec = 127
 
 // execContext is the details of an executed command, and the expected conditions to act on
 type execContext struct {
@@ -35,7 +35,7 @@ func Exec(cmd string, args []string, conf *Conf, outWriter io.Writer) (cmdExitCo
 		case *exec.ExitError:
 			cmdExitCode = e.ExitCode()
 		default:
-			cmdExitCode = EXEC_ERR
+			cmdExitCode = ExitErrExec
 		}
 	}
 	stdoutStr := stdoutBuffer.String()


### PR DESCRIPTION
Use environment variables `MUTE_EXIT_CODES` and `MUTE_STDOUT_PATTERN` to configure current `mute` run without checking the configuration file.

Also minor improvements:
 * Rename constants to follow Go naming conventions (Rename `EXEC_ERR` to `ExitErrExec`)
 * Fix equality check for `Conf` (used to check the `Default` criteria only)
 * Move the logic to get `Conf` in the `cmd` to `mute.GetCmdConf`
 * Define `Conf.IsEmpty` to check for empty configurations 