### PR TITLE
License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,3 +1,6 @@
+License for Mute
+================
+
 Copyright 2019 Farzad Ghanei
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software
@@ -11,3 +14,34 @@ The above copyright notice and this permission notice shall be included in all c
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
 FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+
+Licenses for incorporated software
+==================================
+
+The BurntSushi/toml module is used to parse TOML files in conf.go.
+This module is distributed under the terms of the MIT license, as follows:
+
+
+The MIT License (MIT)
+
+Copyright (c) 2013 TOML authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
 #!/bin/env make -f
+# license: MIT, see LICENSE for details.
 
 SHELL = /bin/sh
 makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))

--- a/README.rst
+++ b/README.rst
@@ -107,7 +107,7 @@ The accessible configuration file should contain valid criteria defenitions in T
 License
 -------
 
-`mute` is an open source project released under the terms of the MIT license.
+`mute` is an open source project released under the terms of the `MIT license <https://opensource.org/licenses/MIT>`_.
 
 The MIT License (MIT)
 

--- a/cmd/mute.go
+++ b/cmd/mute.go
@@ -1,4 +1,5 @@
 // mute executes programs suppressing std streams if required
+// license: MIT, see LICENSE for details.
 package main
 
 import (

--- a/conf.go
+++ b/conf.go
@@ -1,4 +1,6 @@
 // mute executes programs suppressing std streams if required
+// license: MIT, see LICENSE for details.
+// BurntSushi/toml module uses MIT license. see LICENSE for more details
 package mute
 
 import (

--- a/conf_test.go
+++ b/conf_test.go
@@ -1,3 +1,4 @@
+// license: MIT, see LICENSE for details.
 package mute
 
 import (

--- a/exec.go
+++ b/exec.go
@@ -1,4 +1,5 @@
 // package mute implements functions to execute other programs muting std streams if required
+// license: MIT, see LICENSE for details.
 package mute
 
 import (

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,3 +1,4 @@
+// license: MIT, see LICENSE for details.
 package mute
 
 import (

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -4,8 +4,30 @@ Upstream-Contact: Farzad Ghanei
 Source: https://github.com/farzadghanei/mute
 
 Files: *
-Copyright: 2019 Farzad Ghanei
+Copyright: 2019 Farzad Ghanei <farzad.ghanei@tutanota.com>
 License: MIT
+
+Files: BurntSushi/toml/*
+Copyright: Copyright (c) 2013 TOML authors
+License: MIT
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to deal
+    in the Software without restriction, including without limitation the rights
+    to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+    OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+    THE SOFTWARE.
+
 
 License: MIT
  Permission is hereby granted, free of charge, to any person obtaining a copy of this software
@@ -13,9 +35,9 @@ License: MIT
  including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
  and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
  subject to the following conditions:
- 
+
  The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
- 
+
  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
  WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.


### PR DESCRIPTION
improve license information, attribute the [BurntSushi/toml](https://pkg.go.dev/github.com/BurntSushi/toml) module used to parse the configuration files.