### PR TITLE
Integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ go:
 script:
   - make test
   - make
+  - make test-build
 
 notifications:
   email: false

--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,14 @@ build: mute
 test:
 	go test github.com/farzadghanei/mute
 
+test-build: build
+	./mute fixtures/xecho -c 3 > /dev/null; (test "$$?" -eq 3 || false)
+	./mute fixtures/xecho -c 1 'not muted' | grep -q 'not muted'
+	output=$$(env MUTE_EXIT_CODES=1 ./mute fixtures/xecho -c 1 'muted'); test -z "$$output"
+	env MUTE_EXIT_CODDE=1 ./mute fixtures/xecho -c 2 'not muted' | grep -q 'not muted'
+	output=$$(env MUTE_STDOUT_PATTERN='mute.+' ./mute fixtures/xecho 'will be muted.'); test -z "$$output"
+	env MUTE_STDOUT_PATTERN='nottoday' ./mute fixtures/xecho 'not muted' | grep -q 'not muted'
+
 
 install: build
 	$(INSTALL_PROGRAM) -d $(DESTDIR)$(bindir)
@@ -78,4 +86,4 @@ docs:
 	rst2man.py --input-encoding=utf8 --output-encoding=utf8 --strict docs/man/mute.rst docs/man/mute.1
 
 .DEFAULT_GOAL := build
-.PHONY: test build install pkg-deb pkg-clean pkg-deb-setup docs
+.PHONY: test build test-build install pkg-deb pkg-clean pkg-deb-setup docs

--- a/fixtures/xecho
+++ b/fixtures/xecho
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# license: MIT
+# ===========================
+# Copyright 2020 Farzad Ghanei
+# Permission is hereby granted, free of charge, to any person obtaining a copy of this software
+# and associated documentation files (the "Software"), to deal in the Software without restriction,
+# including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense,
+# and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so,
+# subject to the following conditions:
+# The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+# WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+# ===========================
+
+read -r -d '' USAGE << EUSG
+Usage: $0 [-c code] message
+
+prints the input string, and exits with the specific code.
+
+Options:
+    -c exit code
+    -h show this help and exit
+EUSG
+
+
+# opts
+EXITCODE=0
+
+while getopts ":hc:" flag; do
+case "$flag" in
+    h)
+        echo "$USAGE"
+        exit 0
+        ;;
+    c)
+        EXITCODE="$OPTARG"
+        ;;
+    esac
+done
+
+# rest of positional arguments
+ARGS=(${@:$OPTIND})
+
+echo ${ARGS[*]}
+exit $EXITCODE


### PR DESCRIPTION
Add basic integration of the built binary, using the new `test-build` make target. This runs the built binary with some basic cases to make sure the built program behaves as expected.

This `test-build` target runs on Travis CI as part of the build job. 