### PR TITLE
Build deb

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MUTE_LATEST_TAG := $(shell git tag --list | grep --only-matching --line-regexp -
 OS ?= linux
 ARCH ?= amd64
 DIST ?= xenial
-LDFLAGS ?= "-s"  # by default create a leaner binary
+GOLDFLAGS ?= "-s"  # by default create a leaner binary
 GOARCH ?= amd64
 
 ifeq ($(ARCH), amd64)
@@ -46,7 +46,7 @@ cowbuilder = env DISTRIBUTION=$(DIST) ARCH=$(ARCH) BASEPATH=/var/cache/pbuilder/
 
 
 mute:
-	GOOS=$(OS) GOARCH=$(GOARCH) go build -ldflags $(LDFLAGS) cmd/mute.go
+	GOOS=$(OS) GOARCH=$(GOARCH) go build -ldflags $(GOLDFLAGS) cmd/mute.go
 
 
 build: mute

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,10 @@ INSTALL_DATA ?= $(INSTALL -m 644)
 PBUILDER_COMPONENTS ?= "main universe"
 PBUILDER_RC ?= $(makefile_dir)/packaging/pbuilderrc
 
+# find Debian package version from the changelog file. latest version
+# should be at the top, first matching 'mute (0.1.0) ...' and sed clears chars not in version
+MUTE_DEB_VERSION := $(shell grep --only-matching --max-count 1 --perl-regexp "^\s*mute\s+\(.+\)\s*" packaging/debian/changelog | sed 's/[^0-9.]//g')
+
 export ARCH ?= amd64
 export DIST ?= xenial
 
@@ -65,8 +69,7 @@ pkg-deb: export prefix = /usr
 # requires a cowbuilder environment. see pkg-deb-setup
 pkg-deb:
 	(test ! -e debian && echo "no debian directory exists! creating one ..." && /bin/true) || (echo "debian directory exists. Remove to continue. aborting!" && /bin/false)
-	# @TODO: find the package version
-	tar --exclude-vcs -zcf ../mute_0.1.0.orig.tar.gz .
+	tar --exclude-vcs -zcf ../mute_$(MUTE_DEB_VERSION).orig.tar.gz .
 	cp -r packaging/debian debian
 	DIST=$(DIST) ARCH=$(ARCH) BUILDER=cowbuilder GIT_PBUILDER_OPTIONS="--configfile=$(PBUILDER_RC)" git-pbuilder
 

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ MUTE_LATEST_TAG := $(shell git tag --list | grep --only-matching --line-regexp -
 OS ?= linux
 ARCH ?= amd64
 DIST ?= xenial
-LDFLAGS ?= ""
+LDFLAGS ?= "-s"  # by default create a leaner binary
 
 # installation
 DESTDIR ?=

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,13 @@ OS ?= linux
 ARCH ?= amd64
 DIST ?= xenial
 LDFLAGS ?= "-s"  # by default create a leaner binary
+GOARCH ?= amd64
+
+ifeq ($(ARCH), amd64)
+    GOARCH = amd64
+else ifeq ($(ARCH), i368)
+    GOARCH = 386
+endif
 
 # installation
 DESTDIR ?=
@@ -39,7 +46,7 @@ cowbuilder = env DISTRIBUTION=$(DIST) ARCH=$(ARCH) BASEPATH=/var/cache/pbuilder/
 
 
 mute:
-	GOOS=$(OS) GOARCH=$(ARCH) go build -ldflags $(LDFLAGS) cmd/mute.go
+	GOOS=$(OS) GOARCH=$(GOARCH) go build -ldflags $(LDFLAGS) cmd/mute.go
 
 
 build: mute

--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ INSTALL_DATA ?= $(INSTALL -m 644)
 
 
 # packaging
+PKG_DIST_DIR ?= $(abspath $(makefile_dir)/..)
 PKG_TGZ_NAME = mute-$(MUTE_LATEST_TAG)-$(OS)-$(ARCH).tar.gz
 PBUILDER_COMPONENTS ?= "main universe"
 PBUILDER_RC ?= $(makefile_dir)/packaging/pbuilderrc
@@ -85,7 +86,7 @@ pkg-deb:
 	(test ! -e debian && echo "no debian directory exists! creating one ..." && /bin/true) || (echo "debian directory exists. Remove to continue. aborting!" && /bin/false)
 	tar --exclude-vcs -zcf ../mute_$(MUTE_DEB_VERSION).orig.tar.gz .
 	cp -r packaging/debian debian
-	DIST=$(DIST) ARCH=$(ARCH) BUILDER=cowbuilder GIT_PBUILDER_OPTIONS="--configfile=$(PBUILDER_RC)" git-pbuilder
+	env PKG_DIST_DIR=$(PKG_DIST_DIR) DIST=$(DIST) ARCH=$(ARCH) BUILDER=cowbuilder GIT_PBUILDER_OPTIONS="--configfile=$(PBUILDER_RC)" BUILDRESULT=$(PKG_DIST_DIR) git-pbuilder
 
 # required:
 # sudo apt-get install sudo build-essential git-pbuilder devscripts ubuntu-dev-tools
@@ -96,7 +97,7 @@ pkg-deb-setup:
 	echo "add-apt-repository ppa:longsleep/golang-backports; apt-get update;" | sudo $(cowbuilder) --login --save-after-login
 
 pkg-tgz: build
-	tar --create --gzip --exclude-vcs --exclude=docs/man/*.rst --file $(PKG_TGZ_NAME) mute README.rst LICENSE docs/man/mute.1
+	tar --create --gzip --exclude-vcs --exclude=docs/man/*.rst --file $(PKG_DIST_DIR)/$(PKG_TGZ_NAME) mute README.rst LICENSE docs/man/mute.1
 
 pkg-clean:
 	rm -rf debian

--- a/packaging/pbuilderrc
+++ b/packaging/pbuilderrc
@@ -6,6 +6,9 @@ AUTO_DEBSIGN=${AUTO_DEBSIGN:-no}
 
 HOOKDIR=${HOOKDIR:-/var/cache/pbuilder/hooks}
 
+# configure where to place the built packages
+BUILDRESULT=${PKG_DIST_DIR:-../}
+
 # apt repository components
 COMPONENTS=${COMPONENTS:-"main universe"}
 


### PR DESCRIPTION
Improve packaging, preparing for easier auto deployments

* Fix auto detecting the version of the built package in `Makefile`
* Allow customizing the build by Makefile vars (for OS, arch, Go LDFLAGS, etc.)
* Add building a `.tar.gz` binary dist
* Allow customizing the path to store the built deb package