### PR TITLE
Fix Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,8 +39,9 @@ PBUILDER_RC ?= $(makefile_dir)/packaging/pbuilderrc
 RPM_DEV_TREE ?= $(HOME)/rpmbuild
 
 # find Debian package version from the changelog file. latest version
-# should be at the top, first matching 'mute (0.1.0) ...' and sed clears chars not in version
-MUTE_DEB_VERSION := $(shell grep --only-matching --max-count 1 --perl-regexp "^\s*mute\s+\(.+\)\s*" packaging/debian/changelog | sed 's/[^0-9.]//g')
+# should be at the top, first matching 'mute (0.1.0-1) ...' and sed clears chars not in version
+MUTE_DEB_VERSION := $(shell grep --only-matching --max-count 1 --perl-regexp "^\s*mute\s+\(.+\)\s*" packaging/debian/changelog | sed 's/[^0-9.-]//g')
+MUTE_DEB_UPSTREAM_VERSION := $(shell echo $(MUTE_DEB_VERSION) | grep --only-matching --perl-regexp '^[0-9.]+')
 
 # find rpm version from the spec file. latest version
 # should be in the top tags, first matching 'Version: 0.1.0' and sed clears chars not in version
@@ -88,7 +89,7 @@ pkg-deb: export prefix = /usr
 # requires a cowbuilder environment. see pkg-deb-setup
 pkg-deb:
 	(test ! -e debian && echo "no debian directory exists! creating one ..." && /bin/true) || (echo "debian directory exists. Remove to continue. aborting!" && /bin/false)
-	tar --exclude-vcs -zcf ../mute_$(MUTE_DEB_VERSION).orig.tar.gz .
+	tar --exclude-vcs -zcf ../mute_$(MUTE_DEB_UPSTREAM_VERSION).orig.tar.gz .
 	cp -r packaging/debian debian
 	env PKG_DIST_DIR=$(PKG_DIST_DIR) DIST=$(DIST) ARCH=$(ARCH) BUILDER=cowbuilder GIT_PBUILDER_OPTIONS="--configfile=$(PBUILDER_RC)" BUILDRESULT=$(PKG_DIST_DIR) git-pbuilder
 

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,4 +1,4 @@
-mute (0.1.0) UNRELEASED; urgency=low
+mute (0.1.0-1) UNRELEASED; urgency=low
 
   [ Farzad Ghanei ]
   * Handle signals (Closes: #4)

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Maintainer: Farzad Ghanei <farzad.ghanei@tutanota.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), golang-go (>=1.13)
+Build-Depends: debhelper (>= 9), golang-go (>=1.13), git
 
 Package: mute
 Architecture: amd64


### PR DESCRIPTION
The Debian packaging metadata was incorrect:
* missing a proper Debian package version tag in the changelog
* missing `git` as an explicit build dependency

Fixes #12 