### PR TITLE
Improve Debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/sh
 makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 makefile_dir := $(dir $(makefile_path))
 MUTE_LATEST_TAG := $(shell git tag --list | grep --only-matching --line-regexp --perl-regexp '\d+\.\d+\.\d+' | uniq | sort -V | tail -n 1)
-TIMESTAMP_MINUTE := $(shell date -u +%Y%m%d%H%m)
+TIMESTAMP_MINUTE := $(shell date -u +%Y%m%d%H%M)
 
 # build
 OS ?= linux

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -3,7 +3,7 @@ Maintainer: Farzad Ghanei <farzad.ghanei@tutanota.com>
 Section: misc
 Priority: optional
 Standards-Version: 3.9.2
-Build-Depends: debhelper (>= 9), golang-go (>=1.13), git
+Build-Depends: debhelper (>= 9), golang-go (>=1.13), git, ca-certificates
 
 Package: mute
 Architecture: amd64

--- a/packaging/pbuilder-hooks/E01-latestgolang-pkg
+++ b/packaging/pbuilder-hooks/E01-latestgolang-pkg
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# This pbuilder hook is executed after a pbuidler environment create/update.
+# so we can modify the chroot environment.
+#
+# for this hook to be picked up, HOOKDIR variable should be set in pbuilderrc
+# file, or --hookdir should be passed to pbuilder
+#
+# see:
+# https://manpages.debian.org/testing/pbuilder/pbuilder.8.en.html (--hookdir)
+# https://wiki.ubuntu.com/PbuilderHowto#Using_backport_repositories_in_pbuilder
+
+DIST="$DISTRIBUTION"  # DISTRIBUTION is passed by pbuilder
+
+# @TODO: support Debian backports if not on Ubuntu
+echo "Ensuring golang backports PPA ..."
+apt-get update; apt-get install -yq software-properties-common
+add-apt-repository ppa:longsleep/golang-backports; apt-get update
+
+
+

--- a/packaging/pbuilder-hooks/E01-latestgolang-pkg
+++ b/packaging/pbuilder-hooks/E01-latestgolang-pkg
@@ -12,10 +12,17 @@
 
 DIST="$DISTRIBUTION"  # DISTRIBUTION is passed by pbuilder
 
-# @TODO: support Debian backports if not on Ubuntu
-echo "Ensuring golang backports PPA ..."
-apt-get update; apt-get install -yq software-properties-common
-add-apt-repository ppa:longsleep/golang-backports; apt-get update
-
-
-
+if [[ "$DIST" = 'buster' ]]; then
+    if grep --no-messages --no-filename --recursive --fixed-strings buster-backports \
+        /etc/apt/sources.list* | grep -qv --line-regexp '\#.*deb .*'; then
+        echo "Buster backports apt repo already exists"
+    else
+        echo "Ensuring buster backports apt repo ..."
+        echo 'deb http://deb.debian.org/debian buster-backports main' \
+            >>/etc/apt/sources.list.d/buster-backports.list
+    fi
+else
+    echo "Ensuring golang backports PPA ..."
+    apt-get update; apt-get install -yq software-properties-common
+    add-apt-repository ppa:longsleep/golang-backports; apt-get update
+fi

--- a/packaging/pbuilder-hooks/E01-latestgolang-pkg
+++ b/packaging/pbuilder-hooks/E01-latestgolang-pkg
@@ -11,6 +11,7 @@
 # https://wiki.ubuntu.com/PbuilderHowto#Using_backport_repositories_in_pbuilder
 
 DIST="$DISTRIBUTION"  # DISTRIBUTION is passed by pbuilder
+SIGNATUE="created by pbuilder hook 'E01latestgolang-pkg'"
 
 if [[ "$DIST" = 'buster' ]]; then
     if grep --no-messages --no-filename --recursive --fixed-strings buster-backports \
@@ -18,11 +19,27 @@ if [[ "$DIST" = 'buster' ]]; then
         echo "Buster backports apt repo already exists"
     else
         echo "Ensuring buster backports apt repo ..."
-        echo 'deb http://deb.debian.org/debian buster-backports main' \
-            >>/etc/apt/sources.list.d/buster-backports.list
+        cat >> "/etc/apt/sources.list.d/$DIST-backports.list" << EOF
+# $SIGNATUE
+deb http://deb.debian.org/debian $DIST-backports main
+EOF
     fi
+    cat >> "/etc/apt/preferences.d/$DIST-backports" << EOF
+# $SIGNATUE
+# pin backports repo to lower priority for all packages but golang
+# so we can use the latest go compiler
+Package: *
+Pin: release a=$DIST-backports
+Pin-Priority: 10
+
+Package: golang*
+Pin: release a=$DIST-backports
+Pin-Priority: 999
+EOF
 else
     echo "Ensuring golang backports PPA ..."
     apt-get update; apt-get install -yq software-properties-common
     add-apt-repository ppa:longsleep/golang-backports; apt-get update
 fi
+
+apt-get update

--- a/packaging/pbuilderrc
+++ b/packaging/pbuilderrc
@@ -4,8 +4,6 @@
 # by defualt don't sign the deb package
 AUTO_DEBSIGN=${AUTO_DEBSIGN:-no}
 
-HOOKDIR=${HOOKDIR:-/var/cache/pbuilder/hooks}
-
 # configure where to place the built packages
 BUILDRESULT=${PKG_DIST_DIR:-../}
 


### PR DESCRIPTION
* Support building on Debian `buster`, not just Ubuntu Xenial. Using [pbuilder hooks](https://manpages.debian.org/testing/pbuilder/pbuilder.8.en.html) to allow build environment to access to newer Go lang packages, instead of injecting backports PPA in the Makefile, which is the [recommended](https://wiki.ubuntu.com/PbuilderHowto#Using_backport_repositories_in_pbuilder) approach to do so.
* Debian packaging target uses [gbp](https://manpages.debian.org/buster/git-buildpackage/gbp-buildpackage.1.en.html) instead of `git-buildpackage` (which is supposed to be called from `gbp`)