### PR TITLE
Fix RPM packaging, set version to 0.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ SHELL = /bin/sh
 makefile_path := $(abspath $(lastword $(MAKEFILE_LIST)))
 makefile_dir := $(dir $(makefile_path))
 MUTE_LATEST_TAG := $(shell git tag --list | grep --only-matching --line-regexp --perl-regexp '\d+\.\d+\.\d+' | uniq | sort -V | tail -n 1)
-MUTE_VERSION := $(MUTE_LATEST_TAG)
+MUTE_VERSION := $(shell grep --perl-regex '^\s*const\s+Version\s+string' conf.go | grep --only-matching --perl-regexp '[\d\.]+')
 TIMESTAMP_MINUTE := $(shell date -u +%Y%m%d%H%M)
 
 # build

--- a/conf.go
+++ b/conf.go
@@ -14,7 +14,7 @@ import (
 )
 
 // Version is the program version
-const Version string = "0.1.0"
+const Version string = "0.1.1"
 const ENV_CONFIG string = "MUTE_CONFIG"
 const ENV_EXIT_CODES string = "MUTE_EXIT_CODES"
 const ENV_STDOUT_PATTERN string = "MUTE_STDOUT_PATTERN"

--- a/docs/man/mute.1
+++ b/docs/man/mute.1
@@ -1,6 +1,6 @@
 .\" Man page generated from reStructuredText.
 .
-.TH MUTE 1 "2020-02-16" "0.1.0" "General Command Manuals"
+.TH MUTE 1 "2020-02-16" "0.1.1" "General Command Manuals"
 .SH NAME
 MUTE \- runs other programs and prevents the output under configured criteria
 .

--- a/docs/man/mute.rst
+++ b/docs/man/mute.rst
@@ -9,7 +9,7 @@ runs other programs and prevents the output under configured criteria
 :Author: Farzad Ghanei <farzad.ghanei@tutanota.com>
 :Date:   2020-02-16
 :Copyright:  Copyright (c) 2019 Farzad Ghanei. mute is an open source project released under the terms of the MIT license.
-:Version: 0.1.0
+:Version: 0.1.1
 :Manual section: 1
 :Manual group: General Command Manuals
 

--- a/packaging/debian/changelog
+++ b/packaging/debian/changelog
@@ -1,3 +1,14 @@
+mute (0.1.1-1) UNRELEASED; urgency=low
+
+  [ Farzad Ghanei ]
+
+  * Fix missing new line at the end of the help message (Closes: #15)
+  * Fix formatting issues in README
+  * Redo Debian packaging, support Debian buster, use gbp (Closes: #12)
+  * Add RPM packaging
+
+ -- Farzad Ghanei <farzad.ghanei@tutanota.com>  Sun, 16 Aug 2020 12:20:40 +0200
+
 mute (0.1.0-1) UNRELEASED; urgency=low
 
   [ Farzad Ghanei ]

--- a/packaging/mute.spec
+++ b/packaging/mute.spec
@@ -1,5 +1,5 @@
 Name: mute
-Version: 0.1.0
+Version: 0.1.1
 Release: 1%{?dist}
 Summary: Run other programs muting the output when configured
 
@@ -15,9 +15,15 @@ mute runs other programs and mutes the output under configured
 conditions. A good use case is to keep cron jobs silenced and avoid receiving
 emails for known conditions.
 
-%prep
-echo 'no prep needed!'
 
+# go toolchain stores go build id in a different ELF note than GNU toolchain
+# so RPM can't find the build id from the binaries after build.
+# https://github.com/rpm-software-management/rpm/issues/367
+%global _missing_build_ids_terminate_build 0
+%define debug_package %{nil}
+
+%prep
+%setup -c -q
 
 %build
 %make_build
@@ -30,6 +36,10 @@ mkdir -p $RPM_BUILD_ROOT/usr/share/man/man1
 cp -a docs/man/mute.1 $RPM_BUILD_ROOT/usr/share/man/man1/%{name}.1
 
 
+%clean
+rm -rf $RPM_BUILD_ROOT
+
+
 %files
 %license LICENSE
 %doc README.rst
@@ -38,6 +48,12 @@ cp -a docs/man/mute.1 $RPM_BUILD_ROOT/usr/share/man/man1/%{name}.1
 
 
 %changelog
+* Sun Aug 16 2020 Farzad Ghanei <farzad.ghanei@tutanota.com> 0.1.1-1
+- Fix missing new line at the end of the help message (Closes: #15)
+- Fix formatting issues in README
+- Redo Debian packaging, support Debian buster, use gbp (Closes: #12)
+- Add RPM packaging
+
 * Sun Jan 05 2020 Farzad Ghanei <farzad.ghanei@tutanota.com> 0.1.0-1
 - Handle signals (Closes: #4)
 - Use environment variables to configure current run


### PR DESCRIPTION
* Fix RPM packaging due to missing buildid from go tool chain in the compiled binary as expected by `rpmbuild`
* Make file no longer depends on Git to find the version, single source of version is `conf.go`
* Add make target `sync-version` to help update the version
* Set version to `0.1.1`