### PR TITLE
Restructure Exec, reduce chances of memory allocation failures

### DIFF
--- a/cmd/mute.go
+++ b/cmd/mute.go
@@ -14,6 +14,7 @@ func main() {
 		fmt.Fprintf(os.Stderr, "Version %v. Usage: %v COMMAND\n", mute.Version, os.Args[0])
 		os.Exit(mute.ExitErrExec)
 	}
+	var target mute.Target
 	// use config file if accessible, otherwise use a default conf
 	// to mute zero exit codes
 	conf, err := mute.GetCmdConf()
@@ -25,6 +26,7 @@ func main() {
 			os.Exit(mute.ExitErrConf)
 		}
 	}
-	exitCode, _ := mute.Exec(os.Args[1], os.Args[2:], conf, os.Stdout, os.Stderr, 4096)
+	target = mute.Target{Cmd: os.Args[1], Args: os.Args[2:], Conf: conf, OutWriter: os.Stdout, ErrWriter: os.Stderr, BufPreAlloc: 4096}
+	exitCode, _ := target.Exec()
 	os.Exit(exitCode)
 }

--- a/cmd/mute.go
+++ b/cmd/mute.go
@@ -25,6 +25,6 @@ func main() {
 			os.Exit(mute.ExitErrConf)
 		}
 	}
-	exitCode, _ := mute.Exec(os.Args[1], os.Args[2:], conf, os.Stdout, os.Stderr)
+	exitCode, _ := mute.Exec(os.Args[1], os.Args[2:], conf, os.Stdout, os.Stderr, 4096)
 	os.Exit(exitCode)
 }

--- a/cmd/mute.go
+++ b/cmd/mute.go
@@ -4,8 +4,9 @@ package main
 
 import (
 	"fmt"
-	"github.com/farzadghanei/mute"
 	"os"
+
+	"github.com/farzadghanei/mute"
 )
 
 func main() {

--- a/conf.go
+++ b/conf.go
@@ -16,9 +16,15 @@ import (
 
 // Version is the program version
 const Version string = "0.1.1"
-const ENV_CONFIG string = "MUTE_CONFIG"
-const ENV_EXIT_CODES string = "MUTE_EXIT_CODES"
-const ENV_STDOUT_PATTERN string = "MUTE_STDOUT_PATTERN"
+
+// EnvConfig is the name of the environment variable to point to config file
+const EnvConfig string = "MUTE_CONFIG"
+
+// EnvExitCodes is the name of the environment variable to overwrite exit codes
+const EnvExitCodes string = "MUTE_EXIT_CODES"
+
+// EnvStdoutPattern is the name of the environment variable to overwrite stdout regex pattern
+const EnvStdoutPattern string = "MUTE_STDOUT_PATTERN"
 
 // ExitErrConf is exit code when config is invalid
 const ExitErrConf = 126
@@ -264,8 +270,8 @@ func GetCmdConf() (*Conf, error) {
 	var conf *Conf
 	var err error
 
-	envExitCodes := os.Getenv(ENV_EXIT_CODES)
-	envPattern := os.Getenv(ENV_STDOUT_PATTERN)
+	envExitCodes := os.Getenv(EnvExitCodes)
+	envPattern := os.Getenv(EnvStdoutPattern)
 	conf, err = ConfFromEnvStr(envExitCodes, envPattern)
 
 	if err != nil || !conf.IsEmpty() {
@@ -273,7 +279,7 @@ func GetCmdConf() (*Conf, error) {
 	}
 
 	confPath := "/etc/mute.toml"
-	envConfPath, envConfSet := os.LookupEnv(ENV_CONFIG)
+	envConfPath, envConfSet := os.LookupEnv(EnvConfig)
 	if envConfSet {
 		confPath = envConfPath
 		if confPath == "" {

--- a/conf.go
+++ b/conf.go
@@ -1,16 +1,17 @@
-// mute executes programs suppressing std streams if required
+// Package mute executes programs suppressing std streams if required
 // license: MIT, see LICENSE for details.
 // BurntSushi/toml module uses MIT license. see LICENSE for more details
 package mute
 
 import (
 	"fmt"
-	"github.com/BurntSushi/toml"
 	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
 	"strings"
+
+	"github.com/BurntSushi/toml"
 )
 
 // Version is the program version
@@ -27,7 +28,7 @@ type StdoutPattern struct {
 	Regexp *regexp.Regexp
 }
 
-// StdoutPattern.UnmarshalText reads the regex pattern from a byte slice
+// UnmarshalText reads the regex pattern from a byte slice
 func (s *StdoutPattern) UnmarshalText(text []byte) error {
 	var err error
 	re, err := regexp.Compile(string(text))
@@ -35,7 +36,7 @@ func (s *StdoutPattern) UnmarshalText(text []byte) error {
 	return err
 }
 
-// StdoutPattern.String return the regex pattern string
+// String return the regex pattern string
 func (s *StdoutPattern) String() string {
 	return s.Regexp.String()
 }
@@ -67,7 +68,7 @@ func (c *Criterion) String() string {
 	return fmt.Sprintf("<Criterion codes=\"%s\" patterns_count=\"%d\">", strings.Join(codes, ","), len(c.StdoutPatterns))
 }
 
-// Criterion.IsEmpty checks if a Criterion is empty (no exit codes, no patterns)
+// IsEmpty checks if a Criterion is empty (no exit codes, no patterns)
 func (c *Criterion) IsEmpty() bool {
 	return len(c.ExitCodes) < 1 && len(c.StdoutPatterns) < 1
 }
@@ -200,7 +201,7 @@ func (c *Conf) equal(c2 *Conf) bool {
 	return true
 }
 
-// Conf.IsEmpty determines if the Conf is empty
+// IsEmpty determines if the Conf is empty
 func (c *Conf) IsEmpty() bool {
 	return len(c.Default) < 1 && len(c.Commands) < 1
 }

--- a/conf_test.go
+++ b/conf_test.go
@@ -235,11 +235,11 @@ func TestConfFromEnvStr(t *testing.T) {
 func TestGetCmdConfFromEnv(t *testing.T) {
 	var got, want *Conf
 	var err error
-	os.Setenv(ENV_CONFIG, "fixtures/simple.toml")
-	defer os.Unsetenv(ENV_CONFIG)
+	os.Setenv(EnvConfig, "fixtures/simple.toml")
+	defer os.Unsetenv(EnvConfig)
 
-	os.Unsetenv(ENV_EXIT_CODES)
-	os.Unsetenv(ENV_STDOUT_PATTERN)
+	os.Unsetenv(EnvExitCodes)
+	os.Unsetenv(EnvStdoutPattern)
 
 	want = createSimpleConf()
 	got, err = GetCmdConf()
@@ -250,10 +250,10 @@ func TestGetCmdConfFromEnv(t *testing.T) {
 		t.Errorf("GetCmdConf no env conf want simple %v got %v", want, got)
 	}
 
-	os.Setenv(ENV_EXIT_CODES, "")
-	defer os.Unsetenv(ENV_EXIT_CODES)
-	os.Setenv(ENV_STDOUT_PATTERN, "")
-	defer os.Unsetenv(ENV_STDOUT_PATTERN)
+	os.Setenv(EnvExitCodes, "")
+	defer os.Unsetenv(EnvExitCodes)
+	os.Setenv(EnvStdoutPattern, "")
+	defer os.Unsetenv(EnvStdoutPattern)
 
 	got, err = GetCmdConf()
 	if err != nil {
@@ -267,8 +267,8 @@ func TestGetCmdConfFromEnv(t *testing.T) {
 	want = new(Conf)
 	want.Default.add(c1)
 
-	os.Setenv(ENV_EXIT_CODES, "4,5")
-	os.Setenv(ENV_STDOUT_PATTERN, "[0-9]test")
+	os.Setenv(EnvExitCodes, "4,5")
+	os.Setenv(EnvStdoutPattern, "[0-9]test")
 	got, err = GetCmdConf()
 
 	if err != nil {
@@ -278,7 +278,7 @@ func TestGetCmdConfFromEnv(t *testing.T) {
 		t.Errorf("GetCmdConf env want %v got %v", want, got)
 	}
 
-	os.Setenv(ENV_EXIT_CODES, "4,z")
+	os.Setenv(EnvExitCodes, "4,z")
 	got, err = GetCmdConf()
 
 	if err == nil {
@@ -288,8 +288,8 @@ func TestGetCmdConfFromEnv(t *testing.T) {
 		t.Errorf("GetCmdConf env invalid exit code want empty conf, got %v", got)
 	}
 
-	os.Setenv(ENV_EXIT_CODES, "")
-	os.Setenv(ENV_STDOUT_PATTERN, "[")
+	os.Setenv(EnvExitCodes, "")
+	os.Setenv(EnvStdoutPattern, "[")
 	got, err = GetCmdConf()
 
 	if err == nil {
@@ -301,8 +301,8 @@ func TestGetCmdConfFromEnv(t *testing.T) {
 }
 
 func TestGetCmdConfFromFile(t *testing.T) {
-	os.Setenv(ENV_CONFIG, "fixtures/simple.toml")
-	defer os.Unsetenv(ENV_CONFIG)
+	os.Setenv(EnvConfig, "fixtures/simple.toml")
+	defer os.Unsetenv(EnvConfig)
 	want := createSimpleConf()
 	defaultConf := DefaultConf()
 	got, err := GetCmdConf()
@@ -313,7 +313,7 @@ func TestGetCmdConfFromFile(t *testing.T) {
 		t.Errorf("GetCmdConf simple conf want simple %v got %v", want, got)
 	}
 
-	os.Setenv(ENV_CONFIG, "")
+	os.Setenv(EnvConfig, "")
 	got, err = GetCmdConf()
 	if err != nil {
 		t.Errorf("GetCmdConf empty env want no error, got: %v", err)

--- a/conf_test.go
+++ b/conf_test.go
@@ -1,3 +1,4 @@
+// Package mute implements functions to execute other programs muting std streams if required
 // license: MIT, see LICENSE for details.
 package mute
 

--- a/exec.go
+++ b/exec.go
@@ -33,8 +33,8 @@ func Exec(cmd string, args []string, conf *Conf, outWriter io.Writer, errWriter 
 	if cmd == "" {
 		panic("cmd is empty")
 	}
+	crt := cmdCriteria(cmd, conf)
 	ctx := execCmd(cmd, args)
-	crt := cmdCriteria(ctx.Cmd, conf)
 	if !matchesCriteria(crt, ctx.ExitCode, ctx.StdoutText) {
 		fmt.Fprintf(outWriter, "%v", *ctx.StdoutText)
 		fmt.Fprintf(errWriter, "%v", *ctx.StderrText)

--- a/exec.go
+++ b/exec.go
@@ -1,4 +1,4 @@
-// package mute implements functions to execute other programs muting std streams if required
+// Package mute implements functions to execute other programs muting std streams if required
 // license: MIT, see LICENSE for details.
 package mute
 
@@ -59,6 +59,7 @@ func Exec(cmd string, args []string, conf *Conf, outWriter io.Writer, errWriter 
 		}
 	}
 	stdoutStr := stdoutBuffer.String()
+	stdoutBuffer.Reset() // free output from memory
 	ctx := execContext{Cmd: cmd, ExitCode: cmdExitCode, StdoutText: &stdoutStr, Conf: conf}
 	crt := cmdCriteria(ctx.Cmd, ctx.Conf)
 	if !matchesCriteria(crt, ctx.ExitCode, ctx.StdoutText) {
@@ -92,7 +93,7 @@ func matchesCriteria(criteria *Criteria, code int, stdout *string) bool {
 // should be checked against
 func cmdCriteria(cmd string, conf *Conf) *Criteria {
 	matched := ""
-	for key, _ := range conf.Commands {
+	for key := range conf.Commands {
 		if len(key) > len(matched) && strings.HasPrefix(cmd, key) {
 			matched = key
 		}

--- a/exec_test.go
+++ b/exec_test.go
@@ -13,7 +13,7 @@ func TestExecMute(t *testing.T) {
 	var errBuf bytes.Buffer
 	outWriter := bufio.NewWriter(&outBuf)
 	errWriter := bufio.NewWriter(&errBuf)
-	code, err := Exec("go", []string{"version"}, conf, outWriter, errWriter)
+	code, err := Exec("go", []string{"version"}, conf, outWriter, errWriter, 1024)
 	outWriter.Flush()
 	errWriter.Flush()
 	if err != nil {
@@ -38,7 +38,7 @@ func TestExecNoMute(t *testing.T) {
 	var errBuf bytes.Buffer
 	outWriter := bufio.NewWriter(&outBuf)
 	errWriter := bufio.NewWriter(&errBuf)
-	code, err := Exec("go", []string{"invalid"}, conf, outWriter, errWriter)
+	code, err := Exec("go", []string{"invalid"}, conf, outWriter, errWriter, 1024)
 	outWriter.Flush()
 	errWriter.Flush()
 	if err == nil {

--- a/exec_test.go
+++ b/exec_test.go
@@ -1,3 +1,4 @@
+// Package mute implements functions to execute other programs muting std streams if required
 // license: MIT, see LICENSE for details.
 package mute
 
@@ -13,7 +14,8 @@ func TestExecMute(t *testing.T) {
 	var errBuf bytes.Buffer
 	outWriter := bufio.NewWriter(&outBuf)
 	errWriter := bufio.NewWriter(&errBuf)
-	code, err := Exec("go", []string{"version"}, conf, outWriter, errWriter, 1024)
+	target := Target{Cmd: "go", Args: []string{"version"}, Conf: conf, OutWriter: outWriter, ErrWriter: errWriter, BufPreAlloc: 1024}
+	code, err := target.Exec()
 	outWriter.Flush()
 	errWriter.Flush()
 	if err != nil {
@@ -38,7 +40,8 @@ func TestExecNoMute(t *testing.T) {
 	var errBuf bytes.Buffer
 	outWriter := bufio.NewWriter(&outBuf)
 	errWriter := bufio.NewWriter(&errBuf)
-	code, err := Exec("go", []string{"invalid"}, conf, outWriter, errWriter, 1024)
+	target := Target{Cmd: "go", Args: []string{"invalid"}, Conf: conf, OutWriter: outWriter, ErrWriter: errWriter, BufPreAlloc: 1024}
+	code, err := target.Exec()
 	outWriter.Flush()
 	errWriter.Flush()
 	if err == nil {


### PR DESCRIPTION
This PR restructures `mute` package and the `mute.Exec` function.

A buffer is pre-allocated for the `stdout`/`stderr` of the sub command, the configuration criteria is determined before running the sub command not after. These changes could help to reduce chances of memory allocation failures after the sub command is run. So in environments where memory is sparse behavior of `mute` is more consistent.

Also the steps to run the sub command and read the output are refactored to another function, which could help with Go GC to help to free/reuse some of the memory before continuing with checking the results against configurations.

### Changes

* `mute` pre-allocates a buffer for the sub command output (default is 4KB per stream). This reduces the chance of needing to allocate memory after sub command starts (for many cases)

* Redefine how `mute` package executes the sub command. Use the new `mute.Target` struct to specify what to exec, and when to mute and where to print. Now `Exec()` is not a function accepting so many parameters, but a method of the `Target` type.

* `mute.execContext` just carries the results of the execution, and is decoupled from the configuration.

* Constants used for environment variable names are renamed to follow Go naming conventions (the environment variables are still the same).

:warning: This PR breaks the `mute` Go package API, but no change in the application interface.
