### PR TITLE
Static checks

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -34,13 +34,13 @@ jobs:
       - name: Install staticcheck
         run: go install honnef.co/go/tools/cmd/staticcheck@latest
 
-      # - name: Run staticcheck
-      #   run: staticcheck ./...
+      - name: Run staticcheck
+        run: staticcheck ./...
 
       - name: Run tests
         run: go test -race -vet=off ./...
 
-      # - name: golangci-lint
-      #   uses: golangci/golangci-lint-action@v6
-      #   with:
-      #     version: v1.64
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v6
+        with:
+          version: v1.64

--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@
 Mute
 ****
 
-.. image:: https://travis-ci.org/farzadghanei/mute.svg?branch=master
-    :target: https://travis-ci.org/farzadghanei/mute
+.. image:: https://github.com/farzadghanei/mute/workflows/tests/badge.svg
+    :target: https://github.com/farzadghanei/mute/actions
 
 
 ``mute`` runs other programs and mutes the output under configured

--- a/conf.go
+++ b/conf.go
@@ -5,7 +5,6 @@ package mute
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"strconv"
@@ -50,8 +49,7 @@ func (s *StdoutPattern) String() string {
 // NewStdoutPattern returns a pointer to a StdoutPattern object using the regex pattern string
 func NewStdoutPattern(pattern string) *StdoutPattern {
 	var stdp StdoutPattern
-	var re *regexp.Regexp
-	re = regexp.MustCompile(pattern)
+	re := regexp.MustCompile(pattern)
 	stdp = StdoutPattern{Regexp: re}
 	return &stdp
 }
@@ -219,7 +217,7 @@ func (e ConfAccessError) Error() string {
 // ReadConfFile reads config file and returns Conf
 func ReadConfFile(path string) (*Conf, error) {
 	var conf Conf
-	content, err := ioutil.ReadFile(path)
+	content, err := os.ReadFile(path)
 	if err != nil {
 		return &conf, ConfAccessError{err: err, Path: path}
 	}

--- a/exec.go
+++ b/exec.go
@@ -73,7 +73,9 @@ func execCmd(cmd string, args []string, bufPreAlloc int) *execContext {
 	go func() {
 		sig := <-sigs
 		if execCmd.Process != nil { // signal may arrive before cmd starts
-			execCmd.Process.Signal(sig)
+			if execCmd.Process.Signal(sig) != nil {
+				fmt.Fprintf(os.Stderr, "failed to send signal %v to process %d: %v\n", sig, execCmd.Process.Pid, err)
+			}
 		}
 	}()
 	signal.Notify(sigs, syscall.SIGINT, syscall.SIGTERM)

--- a/exec_test.go
+++ b/exec_test.go
@@ -74,8 +74,7 @@ func TestCmdCriteriaReturnCommandSpecific(t *testing.T) {
 	crt1 = append(crt1, c1)
 	crt2 = append(crt2, c2)
 
-	var commandsCriteria map[string]Criteria
-	commandsCriteria = make(map[string]Criteria)
+	commandsCriteria := make(map[string]Criteria)
 	commandsCriteria["test"] = crt1
 	commandsCriteria["testcommand"] = crt2
 	commandsCriteria["somethingelse"] = crt1


### PR DESCRIPTION
1. **CI Badge Update**
   - Updated the CI badge in the `README.rst` file to point to GitHub Actions instead of Travis CI.

2. **Enable Static Checks**
   - Enabled static checks in the GitHub Actions workflow by uncommenting the relevant steps.

3. **Code Improvements**
   - Replaced `ioutil.ReadFile` with `os.ReadFile`
   - Enhanced error handling in the `execCmd` function to log errors on sending signals to processes.
   - Simplified variable initializations

