### PR TITLE
Fix debian packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ MUTE_DEB_UPSTREAM_VERSION := $(shell echo $(MUTE_DEB_VERSION) | grep --only-matc
 MUTE_DEB_UPSTREAM_TARBAL_PATH := $(abspath $(makefile_dir)/..)
 MUTE_DEB_UPSTREAM_TARBAL := $(MUTE_DEB_UPSTREAM_TARBAL_PATH)/mute_$(MUTE_DEB_UPSTREAM_VERSION).orig.tar.gz
 DEB_BUILD_GIT_BRANCH := pkg-deb-$(MUTE_DEB_VERSION)-$(TIMESTAMP_MINUTE)
+export DEB_GO_RW ?= "yes" # deb packaging mark Go module cache as writable for dh clean
 
 # find rpm version from the spec file. latest version
 # should be in the top tags, first matching 'Version: 0.1.0' and sed clears chars not in version
@@ -125,6 +126,7 @@ distclean: clean
 pkg-deb: export prefix = /usr
 # requires a cowbuilder environment. see pkg-deb-setup
 pkg-deb:
+	echo "building a Debian package for mute v$(MUTE_VERSION) with vars: prefix='$(perfix)' DEB_GO_RW='$(DEB_GO_RW)' ..."
 	git checkout -b $(DEB_BUILD_GIT_BRANCH)
 	rm -f $(MUTE_DEB_UPSTREAM_TARBAL); tar --exclude-backups --exclude-vcs -zcf $(MUTE_DEB_UPSTREAM_TARBAL) .
 	cp -r build/package/debian .; git add debian; git commit -m 'add debian dir for packaging v$(MUTE_DEB_VERSION)'

--- a/Makefile
+++ b/Makefile
@@ -91,8 +91,7 @@ build: mute
 
 test:
 	go test -v -race ./...
-	# @TODO: add static checks
-	# if test -z $(TEST_SKIP_STATICCHECKS); then ./scripts/staticchecks; fi
+	if test -z $(TEST_SKIP_STATICCHECKS); then ./scripts/staticchecks; fi
 
 test-build: build
 	./mute test/data/xecho -c 3 > /dev/null; (test "$$?" -eq 3 || false)
@@ -122,11 +121,11 @@ clean:
 
 distclean: clean
 
-# override prefix so .deb package installs binaries to /usr/bin instead of /usr/local/bin
-pkg-deb: export prefix = /usr
 # requires a cowbuilder environment. see pkg-deb-setup
 pkg-deb:
-	echo "building a Debian package for mute v$(MUTE_VERSION) with vars: prefix='$(perfix)' DEB_GO_RW='$(DEB_GO_RW)' ..."
+	# override prefix so .deb package installs binaries to /usr/bin instead of /usr/local/bin
+	$(eval export prefix=/usr)
+	echo "building a Debian package for mute v$(MUTE_VERSION) with vars: prefix=$(prefix) DEB_GO_RW=$(DEB_GO_RW) ..."
 	git checkout -b $(DEB_BUILD_GIT_BRANCH)
 	rm -f $(MUTE_DEB_UPSTREAM_TARBAL); tar --exclude-backups --exclude-vcs -zcf $(MUTE_DEB_UPSTREAM_TARBAL) .
 	cp -r build/package/debian .; git add debian; git commit -m 'add debian dir for packaging v$(MUTE_DEB_VERSION)'

--- a/build/package/debian/rules
+++ b/build/package/debian/rules
@@ -20,5 +20,8 @@ override_dh_clean:
 	# Go modules cache is not writable by default, so
 	# clean will fail to remove it. explicitly make it
 	# writable. See: https://go.dev/ref/mod#module-cache
-	chmod --recursive +w debian/.debhelper/generated/_source/home/go/pkg/
+	echo "running dh_clean override with vars: DEB_GO_RW='$(DEB_GO_RW)' ..."
+	if [ -n "$$DEB_GO_RW" ] && [ -d debian/.debhelper/generated/_source/home/go/pkg/ ]; then \
+		chmod --recursive +w debian/.debhelper/generated/_source/home/go/pkg/; \
+	fi
 	dh_clean

--- a/build/package/debian/rules
+++ b/build/package/debian/rules
@@ -20,7 +20,6 @@ override_dh_clean:
 	# Go modules cache is not writable by default, so
 	# clean will fail to remove it. explicitly make it
 	# writable. See: https://go.dev/ref/mod#module-cache
-	echo "running dh_clean override with vars: DEB_GO_RW='$(DEB_GO_RW)' ..."
 	if [ -n "$$DEB_GO_RW" ] && [ -d debian/.debhelper/generated/_source/home/go/pkg/ ]; then \
 		chmod --recursive +w debian/.debhelper/generated/_source/home/go/pkg/; \
 	fi


### PR DESCRIPTION
improvements to the Debian packaging and Makefile

  - Added a conditional check to make the Go module cache writable only if the `DEB_GO_RW` environment variable is set.
  - Updated the `pkg-deb` target to better export variables used during deb build
  - Enabled static checks by uncommenting the relevant lines in the `test` target.
